### PR TITLE
Use GPLv3 only

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ It gets surprisingly tricky if you drill into details, locales, scripts, calenda
 
 ## 📄 License
 
-Rokuyo Clock is distributed under the terms of [**GNU GPL**](LICENSE) version 3 or any later version.
+Rokuyo Clock is distributed under the terms of [**GNU GPL**](LICENSE) version 3 (exactly).


### PR DESCRIPTION
Remove “or later” clause and provide the code under GPLv3 only, without an option to upgrade.

Due to the recent controversy involving Free Software Foundation, I don't really trust them to automatically upgrade my code to any license they wish to publish.

Since I am the only author, I hereby decree that this licensing change shall be retroactively applied to any previously published version too.